### PR TITLE
remove laravel tricks disqus shortname

### DIFF
--- a/app/views/tricks/single.blade.php
+++ b/app/views/tricks/single.blade.php
@@ -101,7 +101,7 @@ $(function(){$(".js-like-trick").click(function(e){e.preventDefault();if($(this)
 					<div class="col-lg-9 col-md-8">
 						<div id="disqus_thread"></div>
 						<script type="text/javascript">
-							var disqus_shortname = 'laraveltricks';
+							var disqus_shortname = 'YOUR DISQUIS SHORTNAME HERE';
 							var disqus_identifier = '{{$trick->id}}';
 
 							(function() {


### PR DESCRIPTION
I'll see if I can move this into the config file but as a quick fix, I'd recommend to remove your disqus shortname
