### PR TITLE
Fixed finxMostCommented pagination bug

### DIFF
--- a/app/Tricks/Repositories/Eloquent/TrickRepository.php
+++ b/app/Tricks/Repositories/Eloquent/TrickRepository.php
@@ -125,7 +125,12 @@ class TrickRepository extends AbstractRepository implements TrickRepositoryInter
             return $trick->comment_count;
         })->reverse();
 
-        return \Paginator::make($tricks->all(), count($tricks), $perPage);
+        $page = \Input::get('page', 1);
+        $skip = ($page - 1) * $perPage;
+        $items = $tricks->all();
+        array_splice($items, 0, $skip);
+
+        return \Paginator::make($items, count($tricks), $perPage);
     }
 
     /**


### PR DESCRIPTION
In most commented tricks page, pagination does not work. It always showes first top n tricks. So I modified the `TrickRepository.php` to fix this error.
