### PR TITLE
handle cURL errors

### DIFF
--- a/app/Tricks/Exceptions/GithubEmailAccessException.php
+++ b/app/Tricks/Exceptions/GithubEmailAccessException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tricks\Exceptions;
+
+use RuntimeException;
+
+class GithubEmailAccessException extends RuntimeException
+{
+
+}

--- a/app/Tricks/Services/Social/Github.php
+++ b/app/Tricks/Services/Social/Github.php
@@ -149,6 +149,12 @@ class Github
 
         curl_setopt_array($ch, $options);
 
-        return json_decode(curl_exec($ch));
+        $result = curl_exec($ch);
+        if ($result === false) {
+            $error = curl_error($ch);
+            throw new GithubEmailAccessException($error);
+        }
+        
+        return json_decode($result);
     }
 }


### PR DESCRIPTION
I had some troubles to get github authentication working on my new box. Turns out to be an easy problem, but laravel-tricks swallowed the error reported by cURL.

This fixes it and should make it easier for people to track down problems with `SSL certificate problem: unable to get local issuer certificate`
