### PR TITLE
Fix the search bug

### DIFF
--- a/app/Tricks/Repositories/Eloquent/TrickRepository.php
+++ b/app/Tricks/Repositories/Eloquent/TrickRepository.php
@@ -199,12 +199,10 @@ class TrickRepository extends AbstractRepository implements TrickRepositoryInter
                         ->orWhere('title', 'LIKE', '%'.$term.'%')
                         ->orWhere('description', 'LIKE', '%'.$term.'%')
                         ->orWhereHas('tags', function ($query) use ($term) {
-                            $query->where('title', 'LIKE', '%' . $term . '%')
-                                  ->orWhere('slug', 'LIKE', '%' . $term . '%');
+                            $query->where('title', 'LIKE', '%' . $term . '%');
                         })
                         ->orWhereHas('categories', function ($query) use ($term) {
-                            $query->where('name', 'LIKE', '%' . $term . '%')
-                                  ->orWhere('slug', 'LIKE', '%' . $term . '%');
+                            $query->where('name', 'LIKE', '%' . $term . '%');
                         })
                         ->orderBy('created_at', 'desc')
                         ->orderBy('title', 'asc')


### PR DESCRIPTION
If I search the tricks by `test` term, the following SQL is executed.

```SQL
select count(*) as aggregate from `tricks` where `title` LIKE '%test%' or `description` LIKE '%test%' or
 (select count(*) from `tags` inner join `tag_trick` on `tags`.`id` = `tag_trick`.`tag_id` 
  where `tag_trick`.`trick_id` = `tricks`.`id` and `name` LIKE '%test%' or `slug` LIKE '%test%') >= 1 or 
 (select count(*) from `categories` inner join `category_trick` on `categories`.`id` = `category_trick`.`category_id` 
  where `category_trick`.`trick_id` = `tricks`.`id` and `name` LIKE '%test%' or `slug` LIKE '%test%') >= 1
```

Two parts of that SQL causes irrelevant result to the search term.

```SQL
and `name` LIKE '%test%' or `slug` LIKE '%test%'
.
.
.
and `name` LIKE '%test%' or `slug` LIKE '%test%
```

I think that title only would be sufficient for search and in order to fix the above bug, I modified the code.